### PR TITLE
Make the start script filename dyanmic for Confluent distribution compatibility

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -193,3 +193,7 @@ default.kafka.log4j.loggers = {
     additivity: false,
   },
 }
+
+# Define the name of the run script used by our service management system. The
+# confluent distribution of Kafka removes the .sh extension to these files.
+default.kafka.run_script = "bin/kafka-run-class.sh"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'mths@sdrbrg.se'
 license          'Apache 2.0'
 description      'Installs and configures a Kafka broker'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.7.0'
+version          '0.8.0'
 
 recipe 'kafka::default', 'Downloads, compiles and installs Kafka from binary releases'
 

--- a/templates/default/env.erb
+++ b/templates/default/env.erb
@@ -8,6 +8,6 @@ export KAFKA_GC_LOG_OPTS="<%= node.kafka.gc_log_opts %>"
 export KAFKA_OPTS="<%= node.kafka.generic_opts %>"
 export KAFKA_JVM_PERFORMANCE_OPTS="<%= node.kafka.jvm_performance_opts %>"
 
-KAFKA_RUN="<%= node.kafka.install_dir %>/bin/kafka-run-class.sh"
+KAFKA_RUN="<%= node.kafka.install_dir %>/<%= node.kafka.run_script %>"
 KAFKA_ARGS="<%= @main_class %>"
 KAFKA_CONFIG="<%= node.kafka.config_dir %>/server.properties"


### PR DESCRIPTION
The Confluent distribution of Kafka removes the .sh extensions to filenames in the `bin/` directory which breaks this cookbook's environment config for its init script. 

This branch makes that filename a dynamic attribute with a default that doesn't break backwards compatibility.
